### PR TITLE
Rewrite as stable class component, allow passing ref and skipping styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.0.4] - 2019-05-24
+
 ## [0.0.3] - 2019-05-24
 
 ## [0.0.2] - 2019-05-23

--- a/README.md
+++ b/README.md
@@ -5,18 +5,29 @@ Allows mounting arbitrary HTML content in extension points from the comfort and 
 ### Example block
 
 ```
-  "sandbox#test": {
+  "sandbox#product": {
     "props": {
       "width": "200px",
       "height": "60px",
-      "content": "<script src='https://unpkg.com/jquery@3.3.1/dist/jquery.min.js'></script><h1 id='test'>initial</h1><script>$('#test').html(props.productQuery.product.items[0].sellers[0].commertialOffer.ListPrice); console.log(document.cookie)</script>",
+      "initialContent": "<script src='https://unpkg.com/jquery@3.3.1/dist/jquery.min.js'></script><h1 id='test'>initial</h1><script>function render(){ current = window.props.productQuery.product.items.findIndex(function(p){ return p.itemId === window.props.query.skuId }); if (current === -1) {current = 0}; $('#test').html(window.props.productQuery.product.items[current].sellers[0].commertialOffer.ListPrice)}; window.addEventListener('message', function(e){ console.log('got message in product', e.data, window.props); render();});</script>",
       "allowCookies": true
     }
+  },
+  "sandbox#home": {
+    "props": {
+      "width": "200px",
+      "height": "60px",
+      "initialContent": "<h1 id='test'>home</h1><script>console.log(props, document.cookie); window.addEventListener('message', function(e){ console.log('got message in home', window.props) });</script>",
+      "allowCookies": true
+    }
+  },
+  "store.home": {
+    "blocks": ["carousel#home", "shelf#home", "sandbox#home"]
   },
   "store.product": {
     "blocks": [
       "product-details#default",
-      "sandbox#test"
+      "sandbox#product"
     ]
   },
 ```

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "sandbox",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "title": "IO Sandbox Component",
   "description": "IO Sandbox component",
   "defaultLocale": "pt-BR",

--- a/messages/context.json
+++ b/messages/context.json
@@ -1,8 +1,8 @@
 {
   "editor.sandbox.title": "Sandbox",
   "editor.sandbox.description": "A sandbox component that renders HTML content inside a secure iframe",
-  "editor.sandbox.content.title": "Content HTML",
-  "editor.sandbox.content.description": "Any valid HTML. May include scripts. The props passed to this block are available in `window.props`.",
+  "editor.sandbox.initialContent.title": "Initial content HTML",
+  "editor.sandbox.initialContent.description": "Any valid HTML. May include scripts. The props passed to this block are available in `window.props`.",
   "editor.sandbox.width.title": "Width",
   "editor.sandbox.width.description": "Iframe width (e.g. `400px`)",
   "editor.sandbox.height.title": "Height",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,8 +1,8 @@
 {
   "editor.sandbox.title": "Sandbox",
   "editor.sandbox.description": "A sandbox component that renders HTML content inside a secure iframe",
-  "editor.sandbox.content.title": "Content HTML",
-  "editor.sandbox.content.description": "Any valid HTML. May include scripts. The props passed to this block are available in `window.props`.",
+  "editor.sandbox.initialContent.title": "Initial content HTML",
+  "editor.sandbox.initialContent.description": "Any valid HTML. May include scripts. The props passed to this block are available in `window.props`.",
   "editor.sandbox.width.title": "Width",
   "editor.sandbox.width.description": "Iframe width (e.g. `400px`)",
   "editor.sandbox.height.title": "Height",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,8 +1,8 @@
 {
   "editor.sandbox.title": "Sandbox",
   "editor.sandbox.description": "Un componente sandbox que renderiza contenido HTML dentro de un iframe seguro",
-  "editor.sandbox.content.title": "HTML de contenido",
-  "editor.sandbox.content.description": "Cualquier HTML válido. Puede incluir scripts. Las propiedades pasadas a este bloque están disponibles en `window.props`.",
+  "editor.sandbox.initialContent.title": "HTML de contenido inicial",
+  "editor.sandbox.initialContent.description": "Cualquier HTML válido. Puede incluir scripts. Las propiedades pasadas a este bloque están disponibles en `window.props`.",
   "editor.sandbox.width.title": "Largura",
   "editor.sandbox.width.description": "Largura do Iframe (e.g. `400px`)",
   "editor.sandbox.height.title": "Altura",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,8 +1,8 @@
 {
   "editor.sandbox.title": "Sandbox",
   "editor.sandbox.description": "Um componente sandbox que renderiza conteúdo HTML dentro de um iframe seguro",
-  "editor.sandbox.content.title": "HTML de conteúdo",
-  "editor.sandbox.content.description": "Qualquer HTML válido. Pode incluir scripts. As propriedades passadas para este bloco estão disponíveis em `window.props`.",
+  "editor.sandbox.initialContent.title": "HTML de conteúdo inicial",
+  "editor.sandbox.initialContent.description": "Qualquer HTML válido. Pode incluir scripts. As propriedades passadas para este bloco estão disponíveis em `window.props`.",
   "editor.sandbox.width.title": "Largura",
   "editor.sandbox.width.description": "Largura do Iframe (e.g. `400px`)",
   "editor.sandbox.height.title": "Altura",

--- a/react/Sandbox.tsx
+++ b/react/Sandbox.tsx
@@ -1,15 +1,26 @@
-import React, { useEffect, useRef, RefObject } from 'react'
+import React, { RefObject, PureComponent, createRef } from 'react'
 import { NoSSR, canUseDOM } from 'vtex.render-runtime'
 import stringify from 'safe-json-stringify'
 
 interface StyleContainer {
   href?: string
-  rules?: string[]
+  rules?: string
 }
 
 interface IframeOptions {
-  allowCookies: boolean,
-  cookieEventType: string,
+  cookieEventType: string
+  cookie: string
+  styles: StyleContainer[]
+}
+
+interface Props {
+  initialContent?: string
+  width?: string
+  height?: string
+  allowCookies?: boolean
+  allowStyles?: boolean
+  iframeRef?: RefObject<HTMLIFrameElement>
+  hidden?: boolean
 }
 
 // Create objects representing styles, either with href or the actual rules, to be passed to the iframe.
@@ -21,7 +32,7 @@ function getExistingStyles() {
       if (stylesheet.href) {
         styles.push({href: stylesheet.href})
       } else {
-        styles.push({rules: Array.prototype.map.call(stylesheet.rules, (r: any) => r.cssText) as string[] })
+        styles.push({rules: Array.prototype.map.call(stylesheet.rules, (r: any) => r.cssText).join('\n') as string })
       }
     }
   }
@@ -39,10 +50,12 @@ if (canUseDOM) {
   })
 }
 
-function init (options: IframeOptions) {
-  let contentInitialized = false
+function initIframe (options: IframeOptions) {
+  const {styles, cookie, cookieEventType} = options
 
-  if (options.allowCookies) {
+  // Mount cookie
+  if (cookie) {
+    (window as any).__cookie = cookie
     Object.defineProperty(document, 'cookie', {
       get: () => (window as any).__cookie,
       set: (value: string) => {
@@ -51,120 +64,131 @@ function init (options: IframeOptions) {
         }
         const [clean] = value.split(';');
         (window as any).__cookie = `${clean}; ` + (window as any).__cookie
-        window.parent.postMessage({type: options.cookieEventType, value}, '*')
+        window.parent.postMessage({type: cookieEventType, value}, '*')
       },
     })
   }
 
+  // Add styles
+  if (styles && Array.isArray(styles)) {
+    styles.forEach((style: StyleContainer) => {
+      if (style.href) {
+        const link = document.createElement('link')
+        link.href = style.href
+        link.type = 'text/css'
+        link.rel = 'stylesheet'
+        document.head.appendChild(link)
+      } else if (style.rules) {
+        const sheet = document.createElement('style')
+        sheet.innerHTML = style.rules
+        document.head.appendChild(sheet)
+      }
+    })
+  }
+
   window.addEventListener('message', function(event: MessageEvent) {
-    const {styles, props, content, cookie} = event.data
+    const {props} = event.data
     // Add props to window
     if (props) {
       (window as any).props = JSON.parse(props)
     }
-    // Mount cookie
-    if (options.allowCookies && cookie) {
-      (window as any).__cookie = cookie
-    }
-    // Mount block content
-    if (content && !contentInitialized) {
-      contentInitialized = true
-      var range = document.createRange()
-      range.setStart(document.body, 0)
-      document.body.appendChild(range.createContextualFragment(content))
-    }
-    // Add styles
-    if (styles && Array.isArray(styles)) {
-      styles.forEach((style: StyleContainer) => {
-        if (style.href) {
-          const link = document.createElement('link')
-          link.href = style.href
-          link.type = 'text/css'
-          link.rel = 'stylesheet'
-          document.head.appendChild(link)
-        } else if (style.rules) {
-          const sheet = document.createElement('style')
-          sheet.innerHTML = style.rules.join('\n')
-          document.head.appendChild(sheet)
-        }
-      })
-    }
   })
 }
 
-const Sandbox: StorefrontFunctionComponent<SandboxProps> = ({ content, width = '100%', height, allowCookies, allowStyles, iframeRef, hidden, ...props }) => {
-  delete (props as any).runtime
-  const injected = encodeURIComponent(`<script>${init.toString()};init(${stringify({allowCookies, cookieEventType: type})});</script>`)
-  const ref = iframeRef || useRef<HTMLIFrameElement>(null)
+export default class Sandbox extends PureComponent<Props> {
+  public iframeRef: RefObject<HTMLIFrameElement>
 
-  if (allowStyles === undefined) {
-    allowStyles = true
+  public schema = {
+    title: 'editor.sandbox.title',
+    description: 'editor.sandbox.description',
+    type: 'object',
+    properties: {
+      width: {
+        title: 'editor.sandbox.width.title',
+        description: 'editor.sandbox.width.description',
+        type: 'string',
+        default: null,
+      },
+      height: {
+        title: 'editor.sandbox.height.title',
+        description: 'editor.sandbox.height.description',
+        type: 'string',
+        default: null,
+      },
+      initialContent: {
+        title: 'editor.sandbox.initialContent.title',
+        description: 'editor.sandbox.initialContent.description',
+        type: 'string',
+        default: null,
+      },
+      allowCookies: {
+        title: 'editor.sandbox.allowCookies.title',
+        description: 'editor.sandbox.allowCookies.description',
+        type: 'boolean',
+        default: false,
+      },
+    },
   }
 
-  useEffect(() => {
-    if (ref.current && ref.current.contentWindow) {
-      const styles = allowStyles && getExistingStyles()
-      const safeProps = stringify(props)
-      const cookie = allowCookies && document.cookie
-      ref.current.contentWindow.postMessage({props: safeProps, content, styles, cookie}, '*')
+  private injectedDocument: string = ''
+
+  public constructor(props: Props) {
+    super(props)
+    
+    const { initialContent, allowCookies, allowStyles: allowStylesProp } = props
+    const allowStyles = allowStylesProp === undefined ? true : allowStylesProp
+    this.iframeRef = props.iframeRef || createRef<HTMLIFrameElement>()
+    
+    if (!canUseDOM) {
+      return
     }
-  })
+    
+    const cookie = allowCookies && document.cookie
+    const styles = allowStyles && getExistingStyles()
+    this.injectedDocument = `<html><head><script>window.props=${
+      this.safeProps
+    };(${
+      initIframe.toString()
+    })(${
+      stringify({cookieEventType: type, styles, cookie})
+    });</script></head><body>${initialContent}</body></html>`
+  }
 
-  return (
-    <NoSSR>
-      <iframe
-        ref={ref}
-        frameBorder={0}
-        style={hidden ? {display: 'none'} : {width, height}}
-        sandbox="allow-scripts"
-        className="vtex-sandbox-iframe"
-        hidden={hidden}
-        src={"data:text/html,"+injected}>
-      </iframe>
-    </NoSSR>
-  )
+  public componentDidMount() {
+    this.updateIframe()
+  }
+
+  public componentDidUpdate() {
+    this.updateIframe()
+  }
+
+  public render() {
+    const { width = '100%', height, hidden } = this.props
+    return (
+      <NoSSR>
+        <iframe
+          ref={this.iframeRef}
+          frameBorder={0}
+          style={hidden ? {display: 'none'} : {width, height}}
+          sandbox="allow-scripts"
+          className="vtex-sandbox-iframe"
+          hidden={hidden}
+          src={`data:text/html,${encodeURIComponent(this.injectedDocument)}`}>
+        </iframe>
+      </NoSSR>
+    )
+  }
+
+  private get safeProps () {
+    const {runtime, iframeRef, initialContent, allowCookies, height, width, treePath, ...rest} = this.props as any
+    return stringify(rest)
+  }
+
+  private updateIframe() {
+    const ref = this.iframeRef
+    if (ref.current && ref.current.contentWindow) {
+      const props = this.safeProps
+      ref.current.contentWindow.postMessage({props}, '*')
+    }
+  }
 }
-
-interface SandboxProps {
-  content?: string
-  width?: string
-  height?: string
-  allowCookies?: boolean
-  allowStyles?: boolean
-  iframeRef?: RefObject<HTMLIFrameElement>
-  hidden?: boolean
-}
-
-Sandbox.schema = {
-  title: 'editor.sandbox.title',
-  description: 'editor.sandbox.description',
-  type: 'object',
-  properties: {
-    width: {
-      title: 'editor.sandbox.width.title',
-      description: 'editor.sandbox.width.description',
-      type: 'string',
-      default: null,
-    },
-    height: {
-      title: 'editor.sandbox.height.title',
-      description: 'editor.sandbox.height.description',
-      type: 'string',
-      default: null,
-    },
-    content: {
-      title: 'editor.sandbox.content.title',
-      description: 'editor.sandbox.content.description',
-      type: 'string',
-      default: null,
-    },
-    allowCookies: {
-      title: 'editor.sandbox.allowCookies.title',
-      description: 'editor.sandbox.allowCookies.description',
-      type: 'boolean',
-      default: false,
-    },
-  },
-}
-
-export default Sandbox

--- a/react/Sandbox.tsx
+++ b/react/Sandbox.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useRef, RefObject } from 'react'
 import { NoSSR, canUseDOM } from 'vtex.render-runtime'
 import stringify from 'safe-json-stringify'
 
@@ -90,28 +90,28 @@ function init (options: IframeOptions) {
   })
 }
 
-const Sandbox: StorefrontFunctionComponent<SandboxProps> = ({ content, width = '100%', height, allowCookies, allowStyles, ...props }) => {
+const Sandbox: StorefrontFunctionComponent<SandboxProps> = ({ content, width = '100%', height, allowCookies, allowStyles, iframeRef, ...props }) => {
   delete (props as any).runtime
   const injected = encodeURIComponent(`<script>${init.toString()};init(${stringify({allowCookies, cookieEventType: type})});</script>`)
-  const iframeEl = useRef<HTMLIFrameElement>(null)
+  const ref = iframeRef || useRef<HTMLIFrameElement>(null)
 
   if (allowStyles === undefined) {
     allowStyles = true
   }
 
   useEffect(() => {
-    if (iframeEl.current && iframeEl.current.contentWindow) {
+    if (ref.current && ref.current.contentWindow) {
       const styles = allowStyles && getExistingStyles()
       const safeProps = stringify(props)
       const cookie = allowCookies && document.cookie
-      iframeEl.current.contentWindow.postMessage({props: safeProps, content, styles, cookie}, '*')
+      ref.current.contentWindow.postMessage({props: safeProps, content, styles, cookie}, '*')
     }
   })
 
   return (
     <NoSSR>
       <iframe
-        ref={iframeEl}
+        ref={ref}
         frameBorder={0}
         style={{width, height}}
         sandbox="allow-scripts"
@@ -128,6 +128,7 @@ interface SandboxProps {
   height?: string
   allowCookies?: boolean
   allowStyles?: boolean
+  iframeRef?: RefObject<HTMLIFrameElement>
 }
 
 Sandbox.schema = {

--- a/react/Sandbox.tsx
+++ b/react/Sandbox.tsx
@@ -90,14 +90,18 @@ function init (options: IframeOptions) {
   })
 }
 
-const Sandbox: StorefrontFunctionComponent<SandboxProps> = ({ content, width = '100%', height, allowCookies, ...props }) => {
+const Sandbox: StorefrontFunctionComponent<SandboxProps> = ({ content, width = '100%', height, allowCookies, allowStyles, ...props }) => {
   delete (props as any).runtime
   const injected = encodeURIComponent(`<script>${init.toString()};init(${stringify({allowCookies, cookieEventType: type})});</script>`)
   const iframeEl = useRef<HTMLIFrameElement>(null)
 
+  if (allowStyles === undefined) {
+    allowStyles = true
+  }
+
   useEffect(() => {
     if (iframeEl.current && iframeEl.current.contentWindow) {
-      const styles = getExistingStyles()
+      const styles = allowStyles && getExistingStyles()
       const safeProps = stringify(props)
       const cookie = allowCookies && document.cookie
       iframeEl.current.contentWindow.postMessage({props: safeProps, content, styles, cookie}, '*')
@@ -123,6 +127,7 @@ interface SandboxProps {
   width?: string
   height?: string
   allowCookies?: boolean
+  allowStyles?: boolean
 }
 
 Sandbox.schema = {

--- a/react/Sandbox.tsx
+++ b/react/Sandbox.tsx
@@ -69,7 +69,9 @@ function init (options: IframeOptions) {
     // Mount block content
     if (content && !contentInitialized) {
       contentInitialized = true
-      document.write(content)
+      var range = document.createRange()
+      range.setStart(document.body, 0)
+      document.body.appendChild(range.createContextualFragment(content))
     }
     // Add styles
     if (styles && Array.isArray(styles)) {
@@ -90,7 +92,7 @@ function init (options: IframeOptions) {
   })
 }
 
-const Sandbox: StorefrontFunctionComponent<SandboxProps> = ({ content, width = '100%', height, allowCookies, allowStyles, iframeRef, ...props }) => {
+const Sandbox: StorefrontFunctionComponent<SandboxProps> = ({ content, width = '100%', height, allowCookies, allowStyles, iframeRef, hidden, ...props }) => {
   delete (props as any).runtime
   const injected = encodeURIComponent(`<script>${init.toString()};init(${stringify({allowCookies, cookieEventType: type})});</script>`)
   const ref = iframeRef || useRef<HTMLIFrameElement>(null)
@@ -113,9 +115,10 @@ const Sandbox: StorefrontFunctionComponent<SandboxProps> = ({ content, width = '
       <iframe
         ref={ref}
         frameBorder={0}
-        style={{width, height}}
+        style={hidden ? {display: 'none'} : {width, height}}
         sandbox="allow-scripts"
         className="vtex-sandbox-iframe"
+        hidden={hidden}
         src={"data:text/html,"+injected}>
       </iframe>
     </NoSSR>
@@ -129,6 +132,7 @@ interface SandboxProps {
   allowCookies?: boolean
   allowStyles?: boolean
   iframeRef?: RefObject<HTMLIFrameElement>
+  hidden?: boolean
 }
 
 Sandbox.schema = {


### PR DESCRIPTION
Previous version was not predictable upon re-rendering. I changed the name of the `content` property so it's clear it's only inserted at render.

This also makes an effort to not re-render the iframe unless width or height change.

### Test workspace

https://sandbox--storecomponents.myvtex.com/?disableUserLand
https://sandbox--storecomponents.myvtex.com/classic-shoes/p?disableUserLand

**Notice that changing the SKU changes price - props are communicated via postMessage**

### Test blocks applied

```
  "store.home": {
    "blocks": ["carousel#home", "shelf#home", "sandbox#home"]
  },
  "sandbox#product": {
    "props": {
      "width": "200px",
      "height": "60px",
      "initialContent": "<script src='https://unpkg.com/jquery@3.3.1/dist/jquery.min.js'></script><h1 id='test'>initial</h1><script>function render(){ current = window.props.productQuery.product.items.findIndex(function(p){ return p.itemId === window.props.query.skuId }); if (current === -1) {current = 0}; $('#test').html(window.props.productQuery.product.items[current].sellers[0].commertialOffer.ListPrice)}; window.addEventListener('message', function(e){ console.log('got message in product', e.data, window.props); render();});</script>",
      "allowCookies": true
    }
  },
  "sandbox#home": {
    "props": {
      "width": "200px",
      "height": "60px",
      "initialContent": "<h1 id='test'>home</h1><script>console.log(props, document.cookie); window.addEventListener('message', function(e){ console.log('got message in home', window.props) });</script>",
      "allowCookies": true
    }
  },
  "store.product": {
    "blocks": [
      "product-details#default",
      "sandbox#product"
    ]
  },
```