### PR TITLE
Feature/sandbox order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `sandbox.order`, a Sandbox that receives the current OrderForm as props.
 
 ## [0.2.1] - 2019-08-29
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,19 @@ Allows mounting arbitrary HTML content in extension points from the comfort and 
 ### Example block
 
 ```
-  "sandbox#product": {
+  "sandbox.product": {
     "props": {
       "width": "200px",
       "height": "60px",
       "initialContent": "<script src='https://unpkg.com/jquery@3.3.1/dist/jquery.min.js'></script><h1 id='test'>initial</h1><script>function render(){ current = window.props.productQuery.product.items.findIndex(function(p){ return p.itemId === window.props.query.skuId }); if (current === -1) {current = 0}; $('#test').html(window.props.productQuery.product.items[current].sellers[0].commertialOffer.ListPrice)}; window.addEventListener('message', function(e){ console.log('got message in product', e.data, window.props); render();});</script>",
+      "allowCookies": true
+    }
+  },
+  "sandbox.order": {
+    "props": {
+      "width": "200px",
+      "height": "60px",
+      "initialContent": "<script>console.log('Current orderForm: ', window.props.orderForm)</script>",
       "allowCookies": true
     }
   },

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,11 +5,19 @@ Allows mounting arbitrary HTML content in extension points from the comfort and 
 ### Example block
 
 ```
-  "sandbox#product": {
+  "sandbox.product": {
     "props": {
       "width": "200px",
       "height": "60px",
       "initialContent": "<script src='https://unpkg.com/jquery@3.3.1/dist/jquery.min.js'></script><h1 id='test'>initial</h1><script>function render(){ current = window.props.productQuery.product.items.findIndex(function(p){ return p.itemId === window.props.query.skuId }); if (current === -1) {current = 0}; $('#test').html(window.props.productQuery.product.items[current].sellers[0].commertialOffer.ListPrice)}; window.addEventListener('message', function(e){ console.log('got message in product', e.data, window.props); render();});</script>",
+      "allowCookies": true
+    }
+  },
+  "sandbox.order": {
+    "props": {
+      "width": "200px",
+      "height": "60px",
+      "initialContent": "<script>console.log('Current orderForm: ', window.props.orderForm)</script>",
       "allowCookies": true
     }
   },

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,8 @@
   },
   "mustUpdateAt": "2019-04-02",
   "dependencies": {
-    "vtex.product-context": "0.x"
+    "vtex.product-context": "0.x",
+    "vtex.store-resources": "0.x"
   },
   "scripts": {
     "postreleasy": "vtex publish --verbose"

--- a/react/SandboxOrder.tsx
+++ b/react/SandboxOrder.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { Props, schema } from './modules/schema'
+import { useOrderForm } from 'vtex.store-resources/OrderFormContext'
+import Sandbox from './Sandbox'
+
+const SandboxOrder: StorefrontFunctionComponent<Props> = ({
+  initialContent,
+  width,
+  height,
+  allowCookies,
+  allowStyles,
+  hidden,
+}) => {
+  const orderForm = useOrderForm()
+
+  return (
+    <Sandbox
+      orderForm={orderForm}
+      initialContent={initialContent}
+      width={width}
+      height={height}
+      allowCookies={allowCookies}
+      allowStyles={allowStyles}
+      hidden={hidden} />
+  )
+}
+
+SandboxOrder.schema = schema
+
+export default SandboxOrder

--- a/react/modules/schema.ts
+++ b/react/modules/schema.ts
@@ -5,6 +5,7 @@ export interface Props {
   allowCookies?: boolean
   allowStyles?: boolean
   hidden?: boolean
+  [key: string]: any
 }
 
 export const schema = {

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -4,5 +4,8 @@
   },
   "sandbox.product": {
     "component": "SandboxProduct"
+  },
+  "sandbox.order": {
+    "component": "SandboxOrder"
   }
 }


### PR DESCRIPTION
Adds `sandbox.order` block.

Requires this PR https://github.com/vtex-apps/store-resources/pull/58

Test by going into a product page here: https://lbebber--storecomponents.myvtex.com/fashion-eyeglasses/p and adding a product to the cart. There is a `sandbox.order` block on the top of the page. Notice that the product name appears there.