### PR TITLE
Allow sandbox's iframe submit forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allow sandbox's iframe submit forms.
 
 ## [0.3.0] - 2019-09-23
 ### Added

--- a/react/Sandbox.tsx
+++ b/react/Sandbox.tsx
@@ -147,7 +147,7 @@ class Sandbox extends Component<Props> {
           ref={this.setRef}
           frameBorder={0}
           style={hidden ? {display: 'none'} : {width, height}}
-          sandbox="allow-scripts"
+          sandbox="allow-scripts allow-forms"
           className="vtex-sandbox-iframe"
           hidden={hidden}
           src={`data:text/html,${encodeURIComponent(this.injectedDocument)}`}>


### PR DESCRIPTION
#### What is the purpose of this pull request?
Allow submitting forms through the sandbox components. 
#### How should this be manually tested?
Go to https://tom1--gama.myvtex.com/ in the bottom of page there is a form which is builded using sandbox, Fill the form and then submit.
#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/20094423/71006582-44e8ae80-20c4-11ea-8116-473f9dfef6ba.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
