### PR TITLE
Add charset=UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allow sandbox's inframe to read UTF-8.
 
 ## [0.4.0] - 2020-02-07
 ### Added

--- a/react/Sandbox.tsx
+++ b/react/Sandbox.tsx
@@ -150,7 +150,7 @@ class Sandbox extends Component<Props> {
           sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox"
           className="vtex-sandbox-iframe"
           hidden={hidden}
-          src={`data:text/html,${encodeURIComponent(this.injectedDocument)}`}>
+          src={`data:text/html;charset=UTF-8,${encodeURIComponent(this.injectedDocument)}`}>
         </iframe>
       </NoSSR>
     )


### PR DESCRIPTION
**Describe the bug**
When try to use special characters inside the HTML content of the iframe with the site-editor, it doesn't work correctly, showing wrong characters.

**To Reproduce**
Steps to reproduce the behavior:
1. Access: https://unimarcdev.myvtex.com/admin/cms/site-editor/testtest
2. Edit the HTML content in the Sandbox with special characters.
3. Access the page: https://unimarcdev.myvtex.com/testtest

**Expected behavior**
Special characters inserted will turn into wrong characters.

**Screenshots**
If applicable, add screenshots to help explain your problem.
![image](https://user-images.githubusercontent.com/53005772/75581766-eedfa200-5a48-11ea-85e1-5bf3c867e255.png)