### PR TITLE
Update sandbox to allow redirects on the same tab

### DIFF
--- a/react/Sandbox.tsx
+++ b/react/Sandbox.tsx
@@ -147,7 +147,7 @@ class Sandbox extends Component<Props> {
           ref={this.setRef}
           frameBorder={0}
           style={hidden ? {display: 'none'} : {width, height}}
-          sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox"
+          sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-top-navigation"
           className="vtex-sandbox-iframe"
           hidden={hidden}
           src={`data:text/html;charset=UTF-8,${encodeURIComponent(this.injectedDocument)}`}>


### PR DESCRIPTION
I have to open in the same tab, but it's only possible when this new attribut is added

**What problem is this solving?**

Allow sandbox to opne in the same window

**How should this be manually tested?**

Having an anchor tag with the `target="_parent"` attribute and it opens in the same tab
