### PR TITLE
Allow sandbox to open an URL in the current browser context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Allow sandbox's to manipulate its parent frame
+
 ## [0.4.2] - 2020-03-03
 ### Added
 - Allow sandbox's inframe to read UTF-8.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Fixed
-- Allow sandbox's to manipulate its parent frame
+### Added
+- [`allow-top-navigation`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe) to `sandbox` attribute.
 
 ## [0.4.2] - 2020-03-03
 ### Added

--- a/react/Sandbox.tsx
+++ b/react/Sandbox.tsx
@@ -147,7 +147,7 @@ class Sandbox extends Component<Props> {
           ref={this.setRef}
           frameBorder={0}
           style={hidden ? {display: 'none'} : {width, height}}
-          sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox"
+          sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-top-navigation"
           className="vtex-sandbox-iframe"
           hidden={hidden}
           src={`data:text/html;charset=UTF-8,${encodeURIComponent(this.injectedDocument)}`}>


### PR DESCRIPTION
**What problem is this solving?**

- Allow sandbox to open an URL in the same tab

**How should this be manually tested?**

- Having an anchor tag with the target="_parent" attribute and it opens in the same tab